### PR TITLE
Fix race condition cutting stop bit short

### DIFF
--- a/AltSoftSerial.cpp
+++ b/AltSoftSerial.cpp
@@ -135,9 +135,12 @@ ISR(COMPARE_A_INTERRUPT)
 	state = tx_state;
 	byte = tx_byte;
 	target = GET_COMPARE_A();
-	while (state < 9) {
+	while (state < 10) {
 		target += ticks_per_bit;
-		bit = byte & 1;
+		if (state < 9)
+			bit = byte & 1;
+		else
+			bit = 1; // stopbit
 		byte >>= 1;
 		state++;
 		if (bit != tx_bit) {
@@ -153,12 +156,6 @@ ISR(COMPARE_A_INTERRUPT)
 			// TODO: how to detect timing_error?
 			return;
 		}
-	}
-	if (state == 9) {
-		tx_state = 10;
-		CONFIG_MATCH_SET();
-		SET_COMPARE_A(target + ticks_per_bit);
-		return;
 	}
 	head = tx_buffer_head;
 	tail = tx_buffer_tail;


### PR DESCRIPTION
I encountered a race condition that occurs because the TX code does not wait for the stop bit of the last byte in the buffer to complete. If a new byte is written during that stop bit, its start bit gets sent right away, halfway through the previous stop bit, breaking the transmission.

This can be reproduced using this bit of code:

      altSerial.begin(9600);
      altSerial.write('X');
      delayMicroseconds(925);
      altSerial.write('X');

Which looks like this:

![selection_010](https://cloud.githubusercontent.com/assets/194491/9259522/018cf4f2-4202-11e5-9aaf-493c41eb25a5.png)

(Note that there is only a very short high time before the initial start bit, because the first byte is sent directly after reset) For more details, see the first commit with a fix.

The second commit fixes a minor nitpick with the interrupt handler I noticed, which causes one less interrupt to be needed for bytes whose MSB is 1. It's nothing important, just a small improvement. If you don't like the way it is coded, an alternative could be to make the return in the if for the stop bit optional, e.g.:

       if (state == 9) {
               tx_state = 10;
               if (!tx_bit) {
                       CONFIG_MATCH_SET();
                       SET_COMPARE_A(target + ticks_per_bit);
                       return;
               }
       }

This is essentially the same as the commit I proposed, but with the last
loop iteration "unrolled" (but it also increases code by 4 bytes instead
of decreasing by 6).

If you think that the current code is more clear and don't mind the
extra interrupt, that's also fine with me :-)

