### PR TITLE
Fix peek()

### DIFF
--- a/AltSoftSerial.cpp
+++ b/AltSoftSerial.cpp
@@ -285,6 +285,7 @@ int AltSoftSerial::peek(void)
 	head = rx_buffer_head;
 	tail = rx_buffer_tail;
 	if (head == tail) return -1;
+	if (++tail >= RX_BUFFER_SIZE) tail = 0;
 	return rx_buffer[tail];
 }
 


### PR DESCRIPTION
This had an off-by-one, returning the most recently read byte, instead
of the next byte to be read.