### PR TITLE
Bump version number to 1.3

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AltSoftSerial
-version=1.2
+version=1.3
 author=Paul Stoffregen
 maintainer=Paul Stoffregen
 sentence=Software emulated serial using hardware timers for improved compatibility 


### PR DESCRIPTION
It would be great if you could merge this and create a tag, so the version with bugfixes can be downloaded through the library manager. Also, I'm finalizing my book and what to ship the exact library versions used, so it would be great if there is a released version, so I won't have to ship a patched 1.2 version, which will be confusing.