### PR TITLE
Added missing `availableForWrite()` method.

### DIFF
--- a/AltSoftSerial.cpp
+++ b/AltSoftSerial.cpp
@@ -331,6 +331,16 @@ int AltSoftSerial::available(void)
 	return RX_BUFFER_SIZE + head - tail;
 }
 
+int AltSoftSerial::availableForWrite(void)
+{ 
+	uint8_t head, tail;
+	head = tx_buffer_head;
+	tail = tx_buffer_tail;
+
+	if (tail > head) return tail - head;
+	return TX_BUFFER_SIZE + tail - head;
+};
+
 void AltSoftSerial::flushInput(void)
 {
 	rx_buffer_head = rx_buffer_tail;

--- a/AltSoftSerial.h
+++ b/AltSoftSerial.h
@@ -49,6 +49,7 @@ public:
 	int peek();
 	int read();
 	int available();
+	int availableForWrite();
 #if ARDUINO >= 100
 	size_t write(uint8_t byte) { writeByte(byte); return 1; }
 	void flush() { flushOutput(); }


### PR DESCRIPTION
`availableForWrite()` is part of `Print` class which is the parent of `Stream` class and declared as virtual expecting subclasses to define it. However `AltSoftSerial` seems to have missed that and therefore essentially made it impossible to do non-blocking serial communication.

This PR solves this by defining this method.