### PR TITLE
Implement Inverse flag to invert sense of RX and TX like SoftwareSerial

### DIFF
--- a/AltSoftSerial.cpp
+++ b/AltSoftSerial.cpp
@@ -1,17 +1,17 @@
 /* An Alternative Software Serial Library
  * http://www.pjrc.com/teensy/td_libs_AltSoftSerial.html
  * Copyright (c) 2014 PJRC.COM, LLC, Paul Stoffregen, paul@pjrc.com
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -60,12 +60,24 @@ static volatile uint8_t tx_buffer_tail;
 #define TX_BUFFER_SIZE 68
 static volatile uint8_t tx_buffer[TX_BUFFER_SIZE];
 
+static bool invert = false;
+
 
 #ifndef INPUT_PULLUP
 #define INPUT_PULLUP INPUT
 #endif
 
 #define MAX_COUNTS_PER_BIT  6241  // 65536 / 10.5
+
+AltSoftSerial::AltSoftSerial(bool inverse)
+{
+	invert = inverse;
+}
+
+AltSoftSerial::AltSoftSerial(uint8_t rxPin, uint8_t txPin, bool inverse = false)
+{
+	invert = inverse;
+}
 
 void AltSoftSerial::init(uint32_t cycles_per_bit)
 {
@@ -101,15 +113,20 @@ void AltSoftSerial::init(uint32_t cycles_per_bit)
 	}
 	ticks_per_bit = cycles_per_bit;
 	rx_stop_ticks = cycles_per_bit * 37 / 4;
-	pinMode(INPUT_CAPTURE_PIN, INPUT_PULLUP);
-	digitalWrite(OUTPUT_COMPARE_A_PIN, HIGH);
-	pinMode(OUTPUT_COMPARE_A_PIN, OUTPUT);
+    pinMode(INPUT_CAPTURE_PIN, INPUT_PULLUP);
+    pinMode(OUTPUT_COMPARE_A_PIN, OUTPUT);
+    if (invert) {
+		digitalWrite(OUTPUT_COMPARE_A_PIN, LOW);
+	} else {
+			digitalWrite(OUTPUT_COMPARE_A_PIN, HIGH);
+    } // if-else invert
 	rx_state = 0;
 	rx_buffer_head = 0;
 	rx_buffer_tail = 0;
 	tx_state = 0;
 	tx_buffer_head = 0;
 	tx_buffer_tail = 0;
+
 	ENABLE_INT_INPUT_CAPTURE();
 }
 
@@ -117,7 +134,10 @@ void AltSoftSerial::end(void)
 {
 	DISABLE_INT_COMPARE_B();
 	DISABLE_INT_INPUT_CAPTURE();
+
+
 	flushInput();
+
 	flushOutput();
 	DISABLE_INT_COMPARE_A();
 	// TODO: restore timer to original settings?
@@ -145,7 +165,11 @@ void AltSoftSerial::writeByte(uint8_t b)
 		tx_byte = b;
 		tx_bit = 0;
 		ENABLE_INT_COMPARE_A();
-		CONFIG_MATCH_CLEAR();
+		if (invert) {
+			CONFIG_MATCH_SET();
+        } else {
+			CONFIG_MATCH_CLEAR();
+        } //if-else invert
 		SET_COMPARE_A(GET_TIMER_COUNT() + 16);
 	}
 	SREG = intr_state;
@@ -170,10 +194,18 @@ ISR(COMPARE_A_INTERRUPT)
 		state++;
 		if (bit != tx_bit) {
 			if (bit) {
-				CONFIG_MATCH_SET();
+				if (invert) {
+					CONFIG_MATCH_CLEAR();
+				} else {
+					CONFIG_MATCH_SET();
+                } //if-else invert
 			} else {
-				CONFIG_MATCH_CLEAR();
-			}
+				if (invert) {
+					CONFIG_MATCH_SET();
+				} else {
+					CONFIG_MATCH_CLEAR();
+                } //if-else invert
+			} //if-else bit
 			SET_COMPARE_A(target);
 			tx_bit = bit;
 			tx_byte = byte;
@@ -199,7 +231,11 @@ ISR(COMPARE_A_INTERRUPT)
 		tx_buffer_tail = tail;
 		tx_byte = tx_buffer[tail];
 		tx_bit = 0;
-		CONFIG_MATCH_CLEAR();
+		if (invert) {
+			CONFIG_MATCH_SET();
+		} else {
+			CONFIG_MATCH_CLEAR();
+        } //if-else invert
 		if (state == 10)
 			SET_COMPARE_A(target + ticks_per_bit);
 		else
@@ -228,10 +264,18 @@ ISR(CAPTURE_INTERRUPT)
 	capture = GET_INPUT_CAPTURE();
 	bit = rx_bit;
 	if (bit) {
-		CONFIG_CAPTURE_FALLING_EDGE();
+        if (invert) {
+            CONFIG_CAPTURE_RISING_EDGE();
+        } else {
+            CONFIG_CAPTURE_FALLING_EDGE();
+        } //if-else invert;
 		rx_bit = 0;
 	} else {
-		CONFIG_CAPTURE_RISING_EDGE();
+        if (invert) {
+            CONFIG_CAPTURE_FALLING_EDGE();
+        } else {
+            CONFIG_CAPTURE_RISING_EDGE();
+        } //if-else invert
 		rx_bit = 0x80;
 	}
 	state = rx_state;
@@ -260,7 +304,11 @@ ISR(CAPTURE_INTERRUPT)
 					rx_buffer[head] = rx_byte;
 					rx_buffer_head = head;
 				}
-				CONFIG_CAPTURE_FALLING_EDGE();
+                if (invert) {
+                    CONFIG_CAPTURE_RISING_EDGE();
+                } else {
+                    CONFIG_CAPTURE_FALLING_EDGE();
+                } //if-else invert
 				rx_bit = 0;
 				rx_state = 0;
 				return;
@@ -277,7 +325,11 @@ ISR(COMPARE_B_INTERRUPT)
 	uint8_t head, state, bit;
 
 	DISABLE_INT_COMPARE_B();
-	CONFIG_CAPTURE_FALLING_EDGE();
+    if (invert) {
+        CONFIG_CAPTURE_RISING_EDGE();
+    } else {
+        CONFIG_CAPTURE_FALLING_EDGE();
+    } //if-else invert
 	state = rx_state;
 	bit = rx_bit ^ 0x80;
 	while (state < 9) {
@@ -291,7 +343,11 @@ ISR(COMPARE_B_INTERRUPT)
 		rx_buffer_head = head;
 	}
 	rx_state = 0;
-	CONFIG_CAPTURE_FALLING_EDGE();
+    if (invert) {
+        CONFIG_CAPTURE_RISING_EDGE();
+    } else {
+        CONFIG_CAPTURE_FALLING_EDGE();
+    } //if-else invert
 	rx_bit = 0;
 }
 
@@ -330,16 +386,6 @@ int AltSoftSerial::available(void)
 	if (head >= tail) return head - tail;
 	return RX_BUFFER_SIZE + head - tail;
 }
-
-int AltSoftSerial::availableForWrite(void)
-{ 
-	uint8_t head, tail;
-	head = tx_buffer_head;
-	tail = tx_buffer_tail;
-
-	if (tail > head) return tail - head;
-	return TX_BUFFER_SIZE + tail - head;
-};
 
 void AltSoftSerial::flushInput(void)
 {

--- a/AltSoftSerial.cpp
+++ b/AltSoftSerial.cpp
@@ -1,17 +1,17 @@
 /* An Alternative Software Serial Library
  * http://www.pjrc.com/teensy/td_libs_AltSoftSerial.html
  * Copyright (c) 2014 PJRC.COM, LLC, Paul Stoffregen, paul@pjrc.com
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -60,24 +60,12 @@ static volatile uint8_t tx_buffer_tail;
 #define TX_BUFFER_SIZE 68
 static volatile uint8_t tx_buffer[TX_BUFFER_SIZE];
 
-static bool invert = false;
-
 
 #ifndef INPUT_PULLUP
 #define INPUT_PULLUP INPUT
 #endif
 
 #define MAX_COUNTS_PER_BIT  6241  // 65536 / 10.5
-
-AltSoftSerial::AltSoftSerial(bool inverse)
-{
-	invert = inverse;
-}
-
-AltSoftSerial::AltSoftSerial(uint8_t rxPin, uint8_t txPin, bool inverse = false)
-{
-	invert = inverse;
-}
 
 void AltSoftSerial::init(uint32_t cycles_per_bit)
 {
@@ -113,20 +101,15 @@ void AltSoftSerial::init(uint32_t cycles_per_bit)
 	}
 	ticks_per_bit = cycles_per_bit;
 	rx_stop_ticks = cycles_per_bit * 37 / 4;
-    pinMode(INPUT_CAPTURE_PIN, INPUT_PULLUP);
-    pinMode(OUTPUT_COMPARE_A_PIN, OUTPUT);
-    if (invert) {
-		digitalWrite(OUTPUT_COMPARE_A_PIN, LOW);
-	} else {
-			digitalWrite(OUTPUT_COMPARE_A_PIN, HIGH);
-    } // if-else invert
+	pinMode(INPUT_CAPTURE_PIN, INPUT_PULLUP);
+	digitalWrite(OUTPUT_COMPARE_A_PIN, HIGH);
+	pinMode(OUTPUT_COMPARE_A_PIN, OUTPUT);
 	rx_state = 0;
 	rx_buffer_head = 0;
 	rx_buffer_tail = 0;
 	tx_state = 0;
 	tx_buffer_head = 0;
 	tx_buffer_tail = 0;
-
 	ENABLE_INT_INPUT_CAPTURE();
 }
 
@@ -134,10 +117,7 @@ void AltSoftSerial::end(void)
 {
 	DISABLE_INT_COMPARE_B();
 	DISABLE_INT_INPUT_CAPTURE();
-
-
 	flushInput();
-
 	flushOutput();
 	DISABLE_INT_COMPARE_A();
 	// TODO: restore timer to original settings?
@@ -165,11 +145,7 @@ void AltSoftSerial::writeByte(uint8_t b)
 		tx_byte = b;
 		tx_bit = 0;
 		ENABLE_INT_COMPARE_A();
-		if (invert) {
-			CONFIG_MATCH_SET();
-        } else {
-			CONFIG_MATCH_CLEAR();
-        } //if-else invert
+		CONFIG_MATCH_CLEAR();
 		SET_COMPARE_A(GET_TIMER_COUNT() + 16);
 	}
 	SREG = intr_state;
@@ -194,18 +170,10 @@ ISR(COMPARE_A_INTERRUPT)
 		state++;
 		if (bit != tx_bit) {
 			if (bit) {
-				if (invert) {
-					CONFIG_MATCH_CLEAR();
-				} else {
-					CONFIG_MATCH_SET();
-                } //if-else invert
+				CONFIG_MATCH_SET();
 			} else {
-				if (invert) {
-					CONFIG_MATCH_SET();
-				} else {
-					CONFIG_MATCH_CLEAR();
-                } //if-else invert
-			} //if-else bit
+				CONFIG_MATCH_CLEAR();
+			}
 			SET_COMPARE_A(target);
 			tx_bit = bit;
 			tx_byte = byte;
@@ -231,11 +199,7 @@ ISR(COMPARE_A_INTERRUPT)
 		tx_buffer_tail = tail;
 		tx_byte = tx_buffer[tail];
 		tx_bit = 0;
-		if (invert) {
-			CONFIG_MATCH_SET();
-		} else {
-			CONFIG_MATCH_CLEAR();
-        } //if-else invert
+		CONFIG_MATCH_CLEAR();
 		if (state == 10)
 			SET_COMPARE_A(target + ticks_per_bit);
 		else
@@ -264,18 +228,10 @@ ISR(CAPTURE_INTERRUPT)
 	capture = GET_INPUT_CAPTURE();
 	bit = rx_bit;
 	if (bit) {
-        if (invert) {
-            CONFIG_CAPTURE_RISING_EDGE();
-        } else {
-            CONFIG_CAPTURE_FALLING_EDGE();
-        } //if-else invert;
+		CONFIG_CAPTURE_FALLING_EDGE();
 		rx_bit = 0;
 	} else {
-        if (invert) {
-            CONFIG_CAPTURE_FALLING_EDGE();
-        } else {
-            CONFIG_CAPTURE_RISING_EDGE();
-        } //if-else invert
+		CONFIG_CAPTURE_RISING_EDGE();
 		rx_bit = 0x80;
 	}
 	state = rx_state;
@@ -304,11 +260,7 @@ ISR(CAPTURE_INTERRUPT)
 					rx_buffer[head] = rx_byte;
 					rx_buffer_head = head;
 				}
-                if (invert) {
-                    CONFIG_CAPTURE_RISING_EDGE();
-                } else {
-                    CONFIG_CAPTURE_FALLING_EDGE();
-                } //if-else invert
+				CONFIG_CAPTURE_FALLING_EDGE();
 				rx_bit = 0;
 				rx_state = 0;
 				return;
@@ -325,11 +277,7 @@ ISR(COMPARE_B_INTERRUPT)
 	uint8_t head, state, bit;
 
 	DISABLE_INT_COMPARE_B();
-    if (invert) {
-        CONFIG_CAPTURE_RISING_EDGE();
-    } else {
-        CONFIG_CAPTURE_FALLING_EDGE();
-    } //if-else invert
+	CONFIG_CAPTURE_FALLING_EDGE();
 	state = rx_state;
 	bit = rx_bit ^ 0x80;
 	while (state < 9) {
@@ -343,11 +291,7 @@ ISR(COMPARE_B_INTERRUPT)
 		rx_buffer_head = head;
 	}
 	rx_state = 0;
-    if (invert) {
-        CONFIG_CAPTURE_RISING_EDGE();
-    } else {
-        CONFIG_CAPTURE_FALLING_EDGE();
-    } //if-else invert
+	CONFIG_CAPTURE_FALLING_EDGE();
 	rx_bit = 0;
 }
 
@@ -386,6 +330,16 @@ int AltSoftSerial::available(void)
 	if (head >= tail) return head - tail;
 	return RX_BUFFER_SIZE + head - tail;
 }
+
+int AltSoftSerial::availableForWrite(void)
+{ 
+	uint8_t head, tail;
+	head = tx_buffer_head;
+	tail = tx_buffer_tail;
+
+	if (tail > head) return tail - head;
+	return TX_BUFFER_SIZE + tail - head;
+};
 
 void AltSoftSerial::flushInput(void)
 {

--- a/AltSoftSerial.h
+++ b/AltSoftSerial.h
@@ -1,17 +1,17 @@
 /* An Alternative Software Serial Library
  * http://www.pjrc.com/teensy/td_libs_AltSoftSerial.html
  * Copyright (c) 2014 PJRC.COM, LLC, Paul Stoffregen, paul@pjrc.com
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -43,6 +43,7 @@ class AltSoftSerial : public Stream
 {
 public:
 	AltSoftSerial() { }
+    AltSoftSerial(bool inverse);
 	~AltSoftSerial() { end(); }
 	static void begin(uint32_t baud) { init((ALTSS_BASE_FREQ + baud / 2) / baud); }
 	static void end();
@@ -61,7 +62,7 @@ public:
 	static void flushInput();
 	static void flushOutput();
 	// for drop-in compatibility with NewSoftSerial, rxPin & txPin ignored
-	AltSoftSerial(uint8_t rxPin, uint8_t txPin, bool inverse = false) { }
+	AltSoftSerial(uint8_t rxPin, uint8_t txPin, bool inverse = false);
 	bool listen() { return false; }
 	bool isListening() { return true; }
 	bool overflow() { bool r = timing_error; timing_error = false; return r; }

--- a/AltSoftSerial.h
+++ b/AltSoftSerial.h
@@ -1,17 +1,17 @@
 /* An Alternative Software Serial Library
  * http://www.pjrc.com/teensy/td_libs_AltSoftSerial.html
  * Copyright (c) 2014 PJRC.COM, LLC, Paul Stoffregen, paul@pjrc.com
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -43,13 +43,14 @@ class AltSoftSerial : public Stream
 {
 public:
 	AltSoftSerial() { }
+	AltSoftSerial(bool inverse);
+
 	~AltSoftSerial() { end(); }
 	static void begin(uint32_t baud) { init((ALTSS_BASE_FREQ + baud / 2) / baud); }
 	static void end();
 	int peek();
 	int read();
 	int available();
-	int availableForWrite();
 #if ARDUINO >= 100
 	size_t write(uint8_t byte) { writeByte(byte); return 1; }
 	void flush() { flushOutput(); }
@@ -61,7 +62,7 @@ public:
 	static void flushInput();
 	static void flushOutput();
 	// for drop-in compatibility with NewSoftSerial, rxPin & txPin ignored
-	AltSoftSerial(uint8_t rxPin, uint8_t txPin, bool inverse = false) { }
+	AltSoftSerial(uint8_t rxPin, uint8_t txPin, bool inverse = false);
 	bool listen() { return false; }
 	bool isListening() { return true; }
 	bool overflow() { bool r = timing_error; timing_error = false; return r; }

--- a/AltSoftSerial.h
+++ b/AltSoftSerial.h
@@ -1,17 +1,17 @@
 /* An Alternative Software Serial Library
  * http://www.pjrc.com/teensy/td_libs_AltSoftSerial.html
  * Copyright (c) 2014 PJRC.COM, LLC, Paul Stoffregen, paul@pjrc.com
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -43,14 +43,13 @@ class AltSoftSerial : public Stream
 {
 public:
 	AltSoftSerial() { }
-	AltSoftSerial(bool inverse);
-
 	~AltSoftSerial() { end(); }
 	static void begin(uint32_t baud) { init((ALTSS_BASE_FREQ + baud / 2) / baud); }
 	static void end();
 	int peek();
 	int read();
 	int available();
+	int availableForWrite();
 #if ARDUINO >= 100
 	size_t write(uint8_t byte) { writeByte(byte); return 1; }
 	void flush() { flushOutput(); }
@@ -62,7 +61,7 @@ public:
 	static void flushInput();
 	static void flushOutput();
 	// for drop-in compatibility with NewSoftSerial, rxPin & txPin ignored
-	AltSoftSerial(uint8_t rxPin, uint8_t txPin, bool inverse = false);
+	AltSoftSerial(uint8_t rxPin, uint8_t txPin, bool inverse = false) { }
 	bool listen() { return false; }
 	bool isListening() { return true; }
 	bool overflow() { bool r = timing_error; timing_error = false; return r; }


### PR DESCRIPTION
This pull request implements the inverse flag so that AltSoftSerial inverts the sense of RX and TX similar to the inverse flag in SoftwareSerial library.

Unlike the earlier pull request from @BikeMike, the inverse flag affects the sense of *both* the RX and TX pins.  The earlier request only inverted the sense of one line, so it was a partial implementation.  This pull request is a full implementation.

This code has been tested with an inverse serial line device, and a device running with the normal sense of the lines.  Code that ran fine with AltSoftSerial runs fine with this change.  

I implemented this change because I needed to reverse the sense of the lines to communicate with a particular piece of hardware, but I also need full-duplex communication.

This change allows me to run AltSoftSerial to achieve those goals.


