### PR TITLE
Adding support for MKR family Arduinos (SAMD architecture)

### DIFF
--- a/AltSoftSerial.cpp
+++ b/AltSoftSerial.cpp
@@ -176,7 +176,7 @@ void COMPARE_A_ISR()
 {
 	// SAMD architecutre: request current timer value & save until read via `GET_COMPARE_A()` macro
 	timer_request();
-	
+
 #else
 ISR(COMPARE_A_INTERRUPT)
 {
@@ -263,10 +263,11 @@ void AltSoftSerial::flushOutput(void)
 
 #if defined(ALTSS_RX_ATTACHINTERRUPT)
 void INPUT_PIN_ISR()
+{
 #else
 ISR(CAPTURE_INTERRUPT)
-#endif
 {
+#endif
 	uint8_t state, bit, head;
 	uint16_t capture, target;
 	uint16_t offset, offset_overflow;
@@ -419,12 +420,12 @@ void ALTSS_SAMD_TIMER_HANDLER()
 {
 	uint8_t status = ALTSS_SAMD_TC->COUNT16.INTFLAG.reg;
 	uint8_t clear = 0;
-	if (status & TC_INTFLAG_MC1){
-		clear = TC_INTFLAG_MC1;
-		COMPARE_B_ISR();
-	} else if (status & TC_INTFLAG_MC0){
+	if (status & TC_INTFLAG_MC0){
 		clear = TC_INTFLAG_MC0;
 		COMPARE_A_ISR();
+	} else if (status & TC_INTFLAG_MC1){
+		clear = TC_INTFLAG_MC1;
+		COMPARE_B_ISR();
 	} else { // unknown interrupt -> clear all set flags
 		clear = status;
 	}

--- a/config/AltSoftSerial_Boards.h
+++ b/config/AltSoftSerial_Boards.h
@@ -146,7 +146,7 @@
  #define ALTSS_RX_ATTACHINTERRUPT
 
  #define ALTSS_USE_SAMD_TIMER3
- #define INPUT_CAPTURE_PIN		A2 // receive
+ #define INPUT_CAPTURE_PIN		  3 // receive
  #define OUTPUT_COMPARE_A_PIN		2 // transmit
 
 // Unknown board

--- a/config/AltSoftSerial_Boards.h
+++ b/config/AltSoftSerial_Boards.h
@@ -142,6 +142,9 @@
 
 #elif defined(ARDUINO_ARCH_SAMD)
  #define ALTSS_SAMD
+ #define ALTSS_TX_DIGITALWRITE
+ #define ALTSS_RX_ATTACHINTERRUPT
+
  #define ALTSS_USE_SAMD_TIMER3
  #define INPUT_CAPTURE_PIN		A2 // receive
  #define OUTPUT_COMPARE_A_PIN		2 // transmit

--- a/config/AltSoftSerial_Boards.h
+++ b/config/AltSoftSerial_Boards.h
@@ -140,6 +140,11 @@
  #define OUTPUT_COMPARE_B_PIN		12 // unusable PWM
 
 
+#elif defined(ARDUINO_ARCH_SAMD)
+ #define ALTSS_SAMD
+ #define ALTSS_USE_SAMD_TIMER3
+ #define INPUT_CAPTURE_PIN		A2 // receive
+ #define OUTPUT_COMPARE_A_PIN		2 // transmit
 
 // Unknown board
 #else

--- a/config/AltSoftSerial_Timers.h
+++ b/config/AltSoftSerial_Timers.h
@@ -183,5 +183,94 @@
   #endif
   #define ISR(f) static void f (void)
 
+#elif defined(ALTSS_USE_SAMD_TIMER3)
+// Library works with 16 bit timer (implizitly)
+
+void INPUT_PIN_ISR();
+
+// Request the current value of the COUNT register
+inline void timer_request(){
+  // the current value of COUNT will be read even later (except, when COUNT register is written to)
+  TC3->COUNT16.READREQ.reg = TC_READREQ_RREQ | TC_READREQ_ADDR(TC_COUNT16_COUNT_OFFSET);
+};
+
+// Read COUNT register (from point in time when request was mad)
+inline uint16_t timer_read(){
+  // Wait for read-synchronization (if not already done)
+  while(TC3->COUNT16.STATUS.bit.SYNCBUSY);
+  return TC3->COUNT16.COUNT.reg;
+};
+
+// Request & Read COUNT register
+inline uint16_t timer_request_read(){
+  timer_request();
+  return timer_read();
+};
+
+inline void init_timer(uint8_t TC_CTRLA_PRESCALER_Val){
+  const uint16_t GCLK_ID = 3; // use Generic Clock 3
+
+  // Setup GCLK (Generic Clock Controller) for TC3
+  GCLK->GENDIV.bit.ID = GCLK_ID;      // Select Generic Clock ID
+  GCLK->GENDIV.bit.DIV = 1;           // Setup Divison - GCLK = 48MHz / DIV
+  while (GCLK->STATUS.bit.SYNCBUSY);  // Wait for synchronization
+  
+  GCLK->GENCTRL.bit.ID = GCLK_ID;                       // Select Generic Clock ID
+  GCLK->GENCTRL.bit.SRC = GCLK_GENCTRL_SRC_DFLL48M_Val; // Set the 48MHz clock source
+  GCLK->GENCTRL.bit.GENEN = 1;                          // Enable GCLK
+  while (GCLK->STATUS.bit.SYNCBUSY);                    // Wait for synchronization
+
+  GCLK->CLKCTRL.bit.GEN = GCLK_ID;                      // Select the GCLK
+  GCLK->CLKCTRL.bit.ID = GCLK_CLKCTRL_ID_TCC2_TC3_Val;  // Feed the GCLK to TCC2 and TC3
+  GCLK->CLKCTRL.bit.CLKEN = 1;                          // Enable
+  while (GCLK->STATUS.bit.SYNCBUSY);                    // Wait for synchronization
+
+  // Select 16-bit timer counter mode (TC3)
+  // Software reset of TC3; Initialization only possible when TC is disabled -> do a reset
+  TC3->COUNT16.CTRLA.bit.SWRST = 1;
+  while(TC3->COUNT16.CTRLA.bit.SWRST); // Wait for reset to complete
+
+//  TC3->COUNT16.CTRLA.bit.MODE = TC_CTRLA_MODE_COUNT16_Val;        // Counter in 32-bit mode
+//  TC3->COUNT16.CTRLA.bit.WAVEGEN = TC_CTRLA_WAVEGEN_NFRQ_Val;     // WaveGen Mode: Normal Frequency (Top Value is Max)
+  TC3->COUNT16.CTRLA.bit.PRESCALER = TC_CTRLA_PRESCALER_Val; // Set prescaler bits
+  while(TC3->COUNT16.STATUS.bit.SYNCBUSY); 
+
+  
+  // Enable TC3 interrupt (there is only one vector for all TC3 interrupts)
+  NVIC_SetPriority(TC3_IRQn, 0);    // Set the Nested Vector Interrupt Controller (NVIC) priority for TC3 to 0 (highest)
+  NVIC_EnableIRQ(TC3_IRQn);         // Connect TC3 to Nested Vector Interrupt Controller (NVIC)
+
+  // Enable TC3
+  TC3->COUNT16.CTRLA.bit.ENABLE = 1;
+  while(TC3->COUNT16.STATUS.bit.SYNCBUSY); // Wait for synchronization
+};
+
+#define CONFIG_TIMER_NOPRESCALE() (init_timer(TC_CTRLA_PRESCALER_DIV1_Val))
+#define CONFIG_TIMER_PRESCALE_8() (init_timer(TC_CTRLA_PRESCALER_DIV8_Val))
+#define CONFIG_TIMER_PRESCALE_256() (init_timer(TC_CTRLA_PRESCALER_DIV256_Val))
+
+#define SET_COMPARE_A(val) (TC3->COUNT16.CC[0].reg = val)
+#define SET_COMPARE_B(val) (TC3->COUNT16.CC[1].reg = val)
+
+#define ENABLE_INT_COMPARE_A() (TC3->COUNT16.INTENSET.bit.MC0 = 1)
+#define ENABLE_INT_COMPARE_B() (TC3->COUNT16.INTENSET.bit.MC1 = 1)
+#define DISABLE_INT_COMPARE_A() (TC3->COUNT16.INTENCLR.bit.MC0 = 1)
+#define DISABLE_INT_COMPARE_B() (TC3->COUNT16.INTENCLR.bit.MC1 = 1)
+
+#define CONFIG_MATCH_NORMAL() {match_mode = NORMAL;}
+#define CONFIG_MATCH_SET() {match_mode = SET;}
+#define CONFIG_MATCH_CLEAR() {match_mode = CLEAR;}
+
+#define GET_TIMER_COUNT() (timer_request_read())
+#define GET_INPUT_CAPTURE() (timer_request_read())
+#define GET_COMPARE_A() (timer_read())
+
+#define DETACH_PIN_ISR() (detachInterrupt(digitalPinToInterrupt(INPUT_CAPTURE_PIN)))
+#define ATTACH_PIN_ISR(MODE)  {DETACH_PIN_ISR(); \
+                              attachInterrupt(digitalPinToInterrupt(INPUT_CAPTURE_PIN), INPUT_PIN_ISR, MODE);}
+#define ENABLE_INT_INPUT_CAPTURE() (ATTACH_PIN_ISR(CHANGE))
+#define DISABLE_INT_INPUT_CAPTURE() (DETACH_PIN_ISR())
+#define CONFIG_CAPTURE_FALLING_EDGE() (ATTACH_PIN_ISR(FALLING))
+#define CONFIG_CAPTURE_RISING_EDGE() (ATTACH_PIN_ISR(RISING))
 
 #endif

--- a/config/AltSoftSerial_Timers.h
+++ b/config/AltSoftSerial_Timers.h
@@ -184,93 +184,102 @@
   #define ISR(f) static void f (void)
 
 #elif defined(ALTSS_USE_SAMD_TIMER3)
-// Library works with 16 bit timer (implizitly)
+  #define ALTSS_SAMD_TC TC3
+  #define ALTSS_SAMD_TIMER_HANDLER TC3_Handler
+  #define ALTSS_SAMD_TIMER_IRQn TC3_IRQn
+  #define ALTSS_SAMD_GCLK_ID 3  // use Generic Clock 3
+  #define ALTSS_SAMD_GCLK_CLKCTRL_ID GCLK_CLKCTRL_ID_TCC2_TC3_Val
 
-void INPUT_PIN_ISR();
+#endif
 
-// Request the current value of the COUNT register
-inline void timer_request(){
-  // the current value of COUNT will be read even later (except, when COUNT register is written to)
-  TC3->COUNT16.READREQ.reg = TC_READREQ_RREQ | TC_READREQ_ADDR(TC_COUNT16_COUNT_OFFSET);
-};
 
-// Read COUNT register (from point in time when request was mad)
-inline uint16_t timer_read(){
-  // Wait for read-synchronization (if not already done)
-  while(TC3->COUNT16.STATUS.bit.SYNCBUSY);
-  return TC3->COUNT16.COUNT.reg;
-};
+#if defined(ALTSS_RX_ATTACHINTERRUPT)
+  // Use Arduino functions for RX pin
+  void INPUT_PIN_ISR();
 
-// Request & Read COUNT register
-inline uint16_t timer_request_read(){
-  timer_request();
-  return timer_read();
-};
+  #define DETACH_PIN_ISR() (detachInterrupt(digitalPinToInterrupt(INPUT_CAPTURE_PIN)))
+  #define ATTACH_PIN_ISR(MODE)  {DETACH_PIN_ISR(); \
+                                attachInterrupt(digitalPinToInterrupt(INPUT_CAPTURE_PIN), INPUT_PIN_ISR, MODE);}
+  #define ENABLE_INT_INPUT_CAPTURE() (ATTACH_PIN_ISR(CHANGE))
+  #define DISABLE_INT_INPUT_CAPTURE() (DETACH_PIN_ISR())
+  #define CONFIG_CAPTURE_FALLING_EDGE() (ATTACH_PIN_ISR(FALLING))
+  #define CONFIG_CAPTURE_RISING_EDGE() (ATTACH_PIN_ISR(RISING))
 
-inline void init_timer(uint8_t TC_CTRLA_PRESCALER_Val){
-  const uint16_t GCLK_ID = 3; // use Generic Clock 3
+  #define CONFIG_MATCH_NORMAL() {match_mode = NORMAL;}
+  #define CONFIG_MATCH_SET() {match_mode = SET;}
+  #define CONFIG_MATCH_CLEAR() {match_mode = CLEAR;}
 
-  // Setup GCLK (Generic Clock Controller) for TC3
-  GCLK->GENDIV.bit.ID = GCLK_ID;      // Select Generic Clock ID
-  GCLK->GENDIV.bit.DIV = 1;           // Setup Divison - GCLK = 48MHz / DIV
-  while (GCLK->STATUS.bit.SYNCBUSY);  // Wait for synchronization
-  
-  GCLK->GENCTRL.bit.ID = GCLK_ID;                       // Select Generic Clock ID
-  GCLK->GENCTRL.bit.SRC = GCLK_GENCTRL_SRC_DFLL48M_Val; // Set the 48MHz clock source
-  GCLK->GENCTRL.bit.GENEN = 1;                          // Enable GCLK
-  while (GCLK->STATUS.bit.SYNCBUSY);                    // Wait for synchronization
+#endif
 
-  GCLK->CLKCTRL.bit.GEN = GCLK_ID;                      // Select the GCLK
-  GCLK->CLKCTRL.bit.ID = GCLK_CLKCTRL_ID_TCC2_TC3_Val;  // Feed the GCLK to TCC2 and TC3
-  GCLK->CLKCTRL.bit.CLKEN = 1;                          // Enable
-  while (GCLK->STATUS.bit.SYNCBUSY);                    // Wait for synchronization
+#if defined (ALTSS_SAMD)
+  // Request the current value of the COUNT register
+  inline void timer_request(){
+    // the current value of COUNT will be read even later (except, when COUNT register is written to)
+    ALTSS_SAMD_TC->COUNT16.READREQ.reg = TC_READREQ_RREQ | TC_READREQ_ADDR(TC_COUNT16_COUNT_OFFSET);
+  };
 
-  // Select 16-bit timer counter mode (TC3)
-  // Software reset of TC3; Initialization only possible when TC is disabled -> do a reset
-  TC3->COUNT16.CTRLA.bit.SWRST = 1;
-  while(TC3->COUNT16.CTRLA.bit.SWRST); // Wait for reset to complete
+  // Read COUNT register (from point in time when request was mad)
+  inline uint16_t timer_read(){
+    // Wait for read-synchronization (if not already done)
+    while(ALTSS_SAMD_TC->COUNT16.STATUS.bit.SYNCBUSY);
+    return ALTSS_SAMD_TC->COUNT16.COUNT.reg;
+  };
 
-//  TC3->COUNT16.CTRLA.bit.MODE = TC_CTRLA_MODE_COUNT16_Val;        // Counter in 32-bit mode
-//  TC3->COUNT16.CTRLA.bit.WAVEGEN = TC_CTRLA_WAVEGEN_NFRQ_Val;     // WaveGen Mode: Normal Frequency (Top Value is Max)
-  TC3->COUNT16.CTRLA.bit.PRESCALER = TC_CTRLA_PRESCALER_Val; // Set prescaler bits
-  while(TC3->COUNT16.STATUS.bit.SYNCBUSY); 
+  // Request & Read COUNT register
+  inline uint16_t timer_request_read(){
+    timer_request();
+    return timer_read();
+  };
 
-  
-  // Enable TC3 interrupt (there is only one vector for all TC3 interrupts)
-  NVIC_SetPriority(TC3_IRQn, 0);    // Set the Nested Vector Interrupt Controller (NVIC) priority for TC3 to 0 (highest)
-  NVIC_EnableIRQ(TC3_IRQn);         // Connect TC3 to Nested Vector Interrupt Controller (NVIC)
+  inline void init_timer(uint8_t TC_CTRLA_PRESCALER_Val){
+    // Setup GCLK (Generic Clock Controller) for ALTSS_SAMD_TC
+    GCLK->GENDIV.bit.ID = ALTSS_SAMD_GCLK_ID;      // Select Generic Clock ID
+    GCLK->GENDIV.bit.DIV = 1;           // Setup Divison - GCLK = 48MHz / DIV
+    while (GCLK->STATUS.bit.SYNCBUSY);  // Wait for synchronization
+    
+    GCLK->GENCTRL.bit.ID = ALTSS_SAMD_GCLK_ID;      // Select Generic Clock ID
+    GCLK->GENCTRL.bit.SRC = GCLK_GENCTRL_SRC_DFLL48M_Val; // Set the 48MHz clock source
+    GCLK->GENCTRL.bit.GENEN = 1;                          // Enable GCLK
+    while (GCLK->STATUS.bit.SYNCBUSY);                    // Wait for synchronization
 
-  // Enable TC3
-  TC3->COUNT16.CTRLA.bit.ENABLE = 1;
-  while(TC3->COUNT16.STATUS.bit.SYNCBUSY); // Wait for synchronization
-};
+    GCLK->CLKCTRL.bit.GEN = ALTSS_SAMD_GCLK_ID;           // Select the GCLK
+    GCLK->CLKCTRL.bit.ID = ALTSS_SAMD_GCLK_CLKCTRL_ID;    // Feed the GCLK to TCC2 and TC3
+    GCLK->CLKCTRL.bit.CLKEN = 1;                          // Enable
+    while (GCLK->STATUS.bit.SYNCBUSY);                    // Wait for synchronization
 
-#define CONFIG_TIMER_NOPRESCALE() (init_timer(TC_CTRLA_PRESCALER_DIV1_Val))
-#define CONFIG_TIMER_PRESCALE_8() (init_timer(TC_CTRLA_PRESCALER_DIV8_Val))
-#define CONFIG_TIMER_PRESCALE_256() (init_timer(TC_CTRLA_PRESCALER_DIV256_Val))
+    // Select 16-bit timer counter mode (TC3)
+    // Software reset of TC3; Initialization only possible when TC is disabled -> do a reset
+    ALTSS_SAMD_TC->COUNT16.CTRLA.bit.SWRST = 1;
+    while(ALTSS_SAMD_TC->COUNT16.CTRLA.bit.SWRST); // Wait for reset to complete
 
-#define SET_COMPARE_A(val) (TC3->COUNT16.CC[0].reg = val)
-#define SET_COMPARE_B(val) (TC3->COUNT16.CC[1].reg = val)
+  //  TC3->COUNT16.CTRLA.bit.MODE = TC_CTRLA_MODE_COUNT16_Val;        // Counter in 32-bit mode
+  //  TC3->COUNT16.CTRLA.bit.WAVEGEN = TC_CTRLA_WAVEGEN_NFRQ_Val;     // WaveGen Mode: Normal Frequency (Top Value is Max)
+    ALTSS_SAMD_TC->COUNT16.CTRLA.bit.PRESCALER = TC_CTRLA_PRESCALER_Val; // Set prescaler bits
+    while(ALTSS_SAMD_TC->COUNT16.STATUS.bit.SYNCBUSY); 
 
-#define ENABLE_INT_COMPARE_A() (TC3->COUNT16.INTENSET.bit.MC0 = 1)
-#define ENABLE_INT_COMPARE_B() (TC3->COUNT16.INTENSET.bit.MC1 = 1)
-#define DISABLE_INT_COMPARE_A() (TC3->COUNT16.INTENCLR.bit.MC0 = 1)
-#define DISABLE_INT_COMPARE_B() (TC3->COUNT16.INTENCLR.bit.MC1 = 1)
+    
+    // Enable TC3 interrupt (there is only one vector for all TC3 interrupts)
+    NVIC_SetPriority(ALTSS_SAMD_TIMER_IRQn, 0);    // Set the Nested Vector Interrupt Controller (NVIC) priority for TC3 to 0 (highest)
+    NVIC_EnableIRQ(ALTSS_SAMD_TIMER_IRQn);         // Connect TC3 to Nested Vector Interrupt Controller (NVIC)
 
-#define CONFIG_MATCH_NORMAL() {match_mode = NORMAL;}
-#define CONFIG_MATCH_SET() {match_mode = SET;}
-#define CONFIG_MATCH_CLEAR() {match_mode = CLEAR;}
+    // Enable TC3
+    ALTSS_SAMD_TC->COUNT16.CTRLA.bit.ENABLE = 1;
+    while(ALTSS_SAMD_TC->COUNT16.STATUS.bit.SYNCBUSY); // Wait for synchronization
+  };
 
-#define GET_TIMER_COUNT() (timer_request_read())
-#define GET_INPUT_CAPTURE() (timer_request_read())
-#define GET_COMPARE_A() (timer_read())
+  #define CONFIG_TIMER_NOPRESCALE() (init_timer(TC_CTRLA_PRESCALER_DIV1_Val))
+  #define CONFIG_TIMER_PRESCALE_8() (init_timer(TC_CTRLA_PRESCALER_DIV8_Val))
+  #define CONFIG_TIMER_PRESCALE_256() (init_timer(TC_CTRLA_PRESCALER_DIV256_Val))
 
-#define DETACH_PIN_ISR() (detachInterrupt(digitalPinToInterrupt(INPUT_CAPTURE_PIN)))
-#define ATTACH_PIN_ISR(MODE)  {DETACH_PIN_ISR(); \
-                              attachInterrupt(digitalPinToInterrupt(INPUT_CAPTURE_PIN), INPUT_PIN_ISR, MODE);}
-#define ENABLE_INT_INPUT_CAPTURE() (ATTACH_PIN_ISR(CHANGE))
-#define DISABLE_INT_INPUT_CAPTURE() (DETACH_PIN_ISR())
-#define CONFIG_CAPTURE_FALLING_EDGE() (ATTACH_PIN_ISR(FALLING))
-#define CONFIG_CAPTURE_RISING_EDGE() (ATTACH_PIN_ISR(RISING))
+  #define SET_COMPARE_A(val) (ALTSS_SAMD_TC->COUNT16.CC[0].reg = val)
+  #define SET_COMPARE_B(val) (ALTSS_SAMD_TC->COUNT16.CC[1].reg = val)
 
+  #define ENABLE_INT_COMPARE_A() (ALTSS_SAMD_TC->COUNT16.INTENSET.reg = TC_INTENSET_MC0)
+  #define ENABLE_INT_COMPARE_B() (ALTSS_SAMD_TC->COUNT16.INTENSET.reg = TC_INTENSET_MC1)
+  #define DISABLE_INT_COMPARE_A() (ALTSS_SAMD_TC->COUNT16.INTENCLR.reg = TC_INTENSET_MC0)
+  #define DISABLE_INT_COMPARE_B() (ALTSS_SAMD_TC->COUNT16.INTENCLR.reg = TC_INTENCLR_MC1)
+
+  #define GET_TIMER_COUNT() (timer_request_read())
+  #define GET_INPUT_CAPTURE() (timer_request_read())
+  #define GET_COMPARE_A() (timer_read())
 #endif

--- a/config/AltSoftSerial_Timers.h
+++ b/config/AltSoftSerial_Timers.h
@@ -192,22 +192,23 @@
 
 #endif
 
+#if defined(ALTSS_TX_DIGITALWRITE)
+  #define CONFIG_MATCH_NORMAL() {match_mode = NORMAL;}
+  #define CONFIG_MATCH_SET() {match_mode = SET;}
+  #define CONFIG_MATCH_CLEAR() {match_mode = CLEAR;}
+#endif
 
 #if defined(ALTSS_RX_ATTACHINTERRUPT)
   // Use Arduino functions for RX pin
   void INPUT_PIN_ISR();
 
   #define DETACH_PIN_ISR() (detachInterrupt(digitalPinToInterrupt(INPUT_CAPTURE_PIN)))
-  #define ATTACH_PIN_ISR(MODE)  {DETACH_PIN_ISR(); \
-                                attachInterrupt(digitalPinToInterrupt(INPUT_CAPTURE_PIN), INPUT_PIN_ISR, MODE);}
-  #define ENABLE_INT_INPUT_CAPTURE() (ATTACH_PIN_ISR(CHANGE))
+  #define ATTACH_PIN_ISR(MODE)  {attachInterrupt(digitalPinToInterrupt(INPUT_CAPTURE_PIN), INPUT_PIN_ISR, MODE);}
+  #define ENABLE_INT_INPUT_CAPTURE() (ATTACH_PIN_ISR(FALLING))
   #define DISABLE_INT_INPUT_CAPTURE() (DETACH_PIN_ISR())
   #define CONFIG_CAPTURE_FALLING_EDGE() (ATTACH_PIN_ISR(FALLING))
   #define CONFIG_CAPTURE_RISING_EDGE() (ATTACH_PIN_ISR(RISING))
 
-  #define CONFIG_MATCH_NORMAL() {match_mode = NORMAL;}
-  #define CONFIG_MATCH_SET() {match_mode = SET;}
-  #define CONFIG_MATCH_CLEAR() {match_mode = CLEAR;}
 
 #endif
 
@@ -252,8 +253,6 @@
     ALTSS_SAMD_TC->COUNT16.CTRLA.bit.SWRST = 1;
     while(ALTSS_SAMD_TC->COUNT16.CTRLA.bit.SWRST); // Wait for reset to complete
 
-  //  TC3->COUNT16.CTRLA.bit.MODE = TC_CTRLA_MODE_COUNT16_Val;        // Counter in 32-bit mode
-  //  TC3->COUNT16.CTRLA.bit.WAVEGEN = TC_CTRLA_WAVEGEN_NFRQ_Val;     // WaveGen Mode: Normal Frequency (Top Value is Max)
     ALTSS_SAMD_TC->COUNT16.CTRLA.bit.PRESCALER = TC_CTRLA_PRESCALER_Val; // Set prescaler bits
     while(ALTSS_SAMD_TC->COUNT16.STATUS.bit.SYNCBUSY); 
 
@@ -274,10 +273,10 @@
   #define SET_COMPARE_A(val) (ALTSS_SAMD_TC->COUNT16.CC[0].reg = val)
   #define SET_COMPARE_B(val) (ALTSS_SAMD_TC->COUNT16.CC[1].reg = val)
 
-  #define ENABLE_INT_COMPARE_A() (ALTSS_SAMD_TC->COUNT16.INTENSET.reg = TC_INTENSET_MC0)
-  #define ENABLE_INT_COMPARE_B() (ALTSS_SAMD_TC->COUNT16.INTENSET.reg = TC_INTENSET_MC1)
-  #define DISABLE_INT_COMPARE_A() (ALTSS_SAMD_TC->COUNT16.INTENCLR.reg = TC_INTENSET_MC0)
-  #define DISABLE_INT_COMPARE_B() (ALTSS_SAMD_TC->COUNT16.INTENCLR.reg = TC_INTENCLR_MC1)
+  #define ENABLE_INT_COMPARE_A() {ALTSS_SAMD_TC->COUNT16.INTENSET.bit.MC0 = 1 ; ALTSS_SAMD_TC->COUNT16.INTFLAG.bit.MC0 = 1;}
+  #define ENABLE_INT_COMPARE_B() {ALTSS_SAMD_TC->COUNT16.INTENSET.bit.MC1 = 1 ; ALTSS_SAMD_TC->COUNT16.INTFLAG.bit.MC1 = 1;}
+  #define DISABLE_INT_COMPARE_A() (ALTSS_SAMD_TC->COUNT16.INTENCLR.bit.MC0 = 1)
+  #define DISABLE_INT_COMPARE_B() (ALTSS_SAMD_TC->COUNT16.INTENCLR.bit.MC1 = 1)
 
   #define GET_TIMER_COUNT() (timer_request_read())
   #define GET_INPUT_CAPTURE() (timer_request_read())

--- a/config/AltSoftSerial_Timers.h
+++ b/config/AltSoftSerial_Timers.h
@@ -187,17 +187,29 @@
   #define ALTSS_SAMD_TC TC3
   #define ALTSS_SAMD_TIMER_HANDLER TC3_Handler
   #define ALTSS_SAMD_TIMER_IRQn TC3_IRQn
-  #define ALTSS_SAMD_GCLK_ID 3  // use Generic Clock 3
+  #define ALTSS_SAMD_GCLK_ID 3        // use Generic Clock 3
   #define ALTSS_SAMD_GCLK_CLKCTRL_ID GCLK_CLKCTRL_ID_TCC2_TC3_Val
 
 #endif
 
+/* ==========================
+ * AltSoftSerial - use TX digitalWrite
+ * - TX pin can be set to any pin
+ * - should work on all Arduino Boards
+ * (introduced for SAMD boards, work up to 19200 baud)
+ */
 #if defined(ALTSS_TX_DIGITALWRITE)
   #define CONFIG_MATCH_NORMAL() {match_mode = NORMAL;}
   #define CONFIG_MATCH_SET() {match_mode = SET;}
   #define CONFIG_MATCH_CLEAR() {match_mode = CLEAR;}
 #endif
 
+/* ==========================
+ * AltSoftSerial - use RX attachInterrupt
+ * - RX pin can be set to any pin
+ * - should work on all Arduino Boards
+ * (introduced for SAMD boards, work up to 19200 baud)
+ */
 #if defined(ALTSS_RX_ATTACHINTERRUPT)
   // Use Arduino functions for RX pin
   void INPUT_PIN_ISR();
@@ -212,6 +224,11 @@
 
 #endif
 
+/* ==========================
+ * AltSoftSerial - SAMD Timer Setup
+ * - should work on all SAMD boards, tested only on `Arduino MKR Zero`
+ * - using MACROS which where originally designed for AVR boards
+ */
 #if defined (ALTSS_SAMD)
   // Request the current value of the COUNT register
   inline void timer_request(){


### PR DESCRIPTION
I have added support for SAMD architecture type boards (Arduino MKR)
- This code is tested on the _Arduino MKR Zero_ up to a baud rate of 19200
- Using a hardware timer in the same fashion as on the AVR boards
- Due to a more difficult register setup on the SAMD architecture, I have implemented the In- & Output using Arduino functions. Therefore any pin can easily be used (by changing the `#defines`).

This modified code should behave the same on AVR boards as previously & add support for _all_ SAMD architecutre micro controller boards.
When this pull request is merged, it would be great to also modify the compatibility in the Arduino Library manager to include the SAMD architecture / MKR family boards.

Best wishes,
Simon